### PR TITLE
Changing datatype of the server_url column from blob to varchar

### DIFF
--- a/Auth/OpenID/MySQLStore.php
+++ b/Auth/OpenID/MySQLStore.php
@@ -32,7 +32,7 @@ class Auth_OpenID_MySQLStore extends Auth_OpenID_SQLStore {
 
         $this->sql['assoc_table'] =
             "CREATE TABLE %s (\n".
-            "  server_url BLOB NOT NULL,\n".
+            "  server_url VARCHAR(2047) NOT NULL,\n".
             "  handle VARCHAR(255) NOT NULL,\n".
             "  secret BLOB NOT NULL,\n".
             "  issued INTEGER NOT NULL,\n".


### PR DESCRIPTION
All other SQL stores use the <code>varchar(2047)</code> datatype for the <code>server_url</code> columns, only the MySQL store used a <code>blob</code> for the <code>server_url</code> of the assoc_table. This patch fixes this small issue.
