### PR TITLE
Removed hard coded paths to temp directory

### DIFF
--- a/Tests/Auth/OpenID/StoreTest.php
+++ b/Tests/Auth/OpenID/StoreTest.php
@@ -23,15 +23,20 @@ require_once 'Auth/OpenID.php';
 
 function _Auth_OpenID_mkdtemp()
 {
-    if (strpos(PHP_OS, 'WIN') === 0) {
-        $dir = $_ENV['TMP'];
-        if (!isset($dir)) {
-            $dir = 'C:\Windows\Temp';
-        }
-    } else {
-        $dir = @$_ENV['TMPDIR'];
-        if (!isset($dir)) {
-            $dir = '/tmp';
+    if (function_exists('sys_get_temp_dir')) {
+        $dir = sys_get_temp_dir();
+    }
+    else {
+        if (strpos(PHP_OS, 'WIN') === 0) {
+            $dir = $_ENV['TMP'];
+            if (!isset($dir)) {
+                $dir = 'C:\Windows\Temp';
+            }
+        } else {
+            $dir = @$_ENV['TMPDIR'];
+            if (!isset($dir)) {
+                $dir = '/tmp';
+            }
         }
     }
 

--- a/examples/consumer/common.php
+++ b/examples/consumer/common.php
@@ -50,7 +50,25 @@ function &getStore() {
      * created elsewhere.  After you're done playing with the example
      * script, you'll have to remove this directory manually.
      */
-    $store_path = "/tmp/_php_consumer_test";
+    $store_path = null;
+    if (function_exists('sys_get_temp_dir')) {
+        $store_path = sys_get_temp_dir();
+    }
+    else {
+        if (strpos(PHP_OS, 'WIN') === 0) {
+            $store_path = $_ENV['TMP'];
+            if (!isset($store_path)) {
+                $dir = 'C:\Windows\Temp';
+            }
+        }
+        else {
+            $store_path = @$_ENV['TMPDIR'];
+            if (!isset($store_path)) {
+                $store_path = '/tmp';
+            }
+        }
+    }
+    $store_path .= DIRECTORY_SEPARATOR . '_php_consumer_test';
 
     if (!file_exists($store_path) &&
         !mkdir($store_path)) {


### PR DESCRIPTION
Hi,

my webhoster recently updated his PHP version and moved the /tmp directory from /tmp to /var/tmp/php/[username]. The old /tmp directory isn't accessible for PHP anymore, so the consumer example crashed.
I added a temp path detection to the example and to Auth::OpenID::Auth_OpenID_mkdtemp.

Regards
Phil
