### PR TITLE
Fix detect

### DIFF
--- a/examples/detect.php
+++ b/examples/detect.php
@@ -434,7 +434,7 @@ function detect_fetcher($r, &$out)
 
     $ok = true;
     $fetcher = Auth_Yadis_Yadis::getHTTPFetcher();
-    $fetch_url = 'http://gist.github.com/raw/465630/c57eff55ebc0c54973903af5f72bac72762cf4f4/helloworld';
+    $fetch_url = 'https://raw.github.com/gist/465630/c57eff55ebc0c54973903af5f72bac72762cf4f4/helloworld';
     $expected_url = $fetch_url;// . '.txt';
     $result = $fetcher->get($fetch_url);
 


### PR DESCRIPTION
The detect.php script has a couple of minor issues with the HTTP fetching test. One is the actual URL fetched doesn't get displayed properly if it is different from the expected URL when the output is text/html. The other is that the URL itself should be updated since github is redirecting the original one.
