### PR TITLE
Removed logging calls for a successful retrieval, as the PlainHTTPFetcher doesn't perform logging on a successful commit.

### DIFF
--- a/Auth/Yadis/ParanoidHTTPFetcher.php
+++ b/Auth/Yadis/ParanoidHTTPFetcher.php
@@ -166,10 +166,6 @@ class Auth_Yadis_ParanoidHTTPFetcher extends Auth_Yadis_HTTPFetcher {
                     }
                 }
 
-                Auth_OpenID::log(
-                    "Successfully fetched '%s': GET response code %s",
-                    $url, $code);
-
                 return new Auth_Yadis_HTTPResponse($url, $code,
                                                     $new_headers, $body);
             }
@@ -234,9 +230,6 @@ class Auth_Yadis_ParanoidHTTPFetcher extends Auth_Yadis_HTTPFetcher {
             }
 
         }
-
-        Auth_OpenID::log("Successfully fetched '%s': POST response code %s",
-                         $url, $code);
 
         return new Auth_Yadis_HTTPResponse($url, $code,
                                            $new_headers, $body);


### PR DESCRIPTION
Removed logging calls for a successful retrieval, as the PlainHTTPFetcher doesn't perform logging on a successful commit.
