### PR TITLE
Remove call-time pass-by-reference

### DIFF
--- a/Auth/OpenID/Consumer.php
+++ b/Auth/OpenID/Consumer.php
@@ -1183,9 +1183,11 @@ class Auth_OpenID_GenericConsumer {
     function _discoverAndVerify($claimed_id, $to_match_endpoints)
     {
         // oidutil.log('Performing discovery on %s' % (claimed_id,))
-        list($unused, $services) = call_user_func($this->discoverMethod,
-                                                  $claimed_id,
-                                                  &$this->fetcher);
+        list($unused, $services) = call_user_func_array($this->discoverMethod,
+                                                        array(
+                                                            $claimed_id,
+                                                            &$this->fetcher,
+                                                        ));
 
         if (!$services) {
             return new Auth_OpenID_FailureResponse(null,

--- a/Auth/OpenID/Server.php
+++ b/Auth/OpenID/Server.php
@@ -1704,7 +1704,7 @@ class Auth_OpenID_Server {
     {
         if (method_exists($this, "openid_" . $request->mode)) {
             $handler = array($this, "openid_" . $request->mode);
-            return call_user_func($handler, &$request);
+            return call_user_func_array($handler, array(&$request));
         }
         return null;
     }

--- a/Auth/Yadis/Manager.php
+++ b/Auth/Yadis/Manager.php
@@ -411,9 +411,11 @@ class Auth_Yadis_Discovery {
         if (!$manager || (!$manager->services)) {
             $this->destroyManager();
 
-            list($yadis_url, $services) = call_user_func($discover_cb,
-                                                         $this->url,
-                                                         &$fetcher);
+            list($yadis_url, $services) = call_user_func_array($discover_cb,
+                                                               array(
+                                                                $this->url,
+                                                                &$fetcher,
+                                                               ));
 
             $manager = $this->createManager($services, $yadis_url);
         }


### PR DESCRIPTION
This removes some call-time pass-by-references. Passing an argument by reference at call time has been deprecated since at least php 5.3 (triggers E_DEPRECATED errors), and is not supported any more in php 5.4.
