### PR TITLE
Fixed call-time pass-by-references

### DIFF
--- a/Auth/OpenID/Consumer.php
+++ b/Auth/OpenID/Consumer.php
@@ -1185,7 +1185,7 @@ class Auth_OpenID_GenericConsumer {
         // oidutil.log('Performing discovery on %s' % (claimed_id,))
         list($unused, $services) = call_user_func($this->discoverMethod,
                                                   $claimed_id,
-                                                  &$this->fetcher);
+                                                  $this->fetcher);
 
         if (!$services) {
             return new Auth_OpenID_FailureResponse(null,

--- a/Auth/OpenID/Server.php
+++ b/Auth/OpenID/Server.php
@@ -1704,7 +1704,7 @@ class Auth_OpenID_Server {
     {
         if (method_exists($this, "openid_" . $request->mode)) {
             $handler = array($this, "openid_" . $request->mode);
-            return call_user_func($handler, &$request);
+            return call_user_func($handler, $request);
         }
         return null;
     }

--- a/Auth/Yadis/Manager.php
+++ b/Auth/Yadis/Manager.php
@@ -413,7 +413,7 @@ class Auth_Yadis_Discovery {
 
             list($yadis_url, $services) = call_user_func($discover_cb,
                                                          $this->url,
-                                                         &$fetcher);
+                                                         $fetcher);
 
             $manager = $this->createManager($services, $yadis_url);
         }


### PR DESCRIPTION
As of PHP 5.4 "call-time pass-by-reference" throws fatal error. This fix removes some of such code.
