### PR TITLE
Fixing "preg_match_all() expects parameter 2 to be string, array given" error

### DIFF
--- a/Auth/OpenID/Parse.php
+++ b/Auth/OpenID/Parse.php
@@ -219,7 +219,11 @@ class Auth_OpenID_Parse {
     function match($regexp, $text, &$match)
     {
         if (!is_callable('mb_ereg_search_init')) {
-            return preg_match($regexp, $text, $match);
+            if (!preg_match($regexp, $text, $match)) {
+                return false;
+            }
+            $match = $match[0];
+            return true;
         }
 
         $regexp = substr($regexp, 1, strlen($regexp) - 2 - strlen($this->_re_flags));


### PR DESCRIPTION
When using PHP with the mbstring extension not enabled, you will get a "preg_match_all() expects parameter 2 to be string, array given" error when you try to make an OpenID request.

The problem is that in this case the method Auth_OpenID_Parse#match() returns an array whereas it returns a string when the mbstring extension is enabled.

This fix makes the method return a string in both cases.
