### PR TITLE
return Auth_OpenID_FailureResponse instead null when curl post or get fails due to certificate errors

### DIFF
--- a/Auth/OpenID/Consumer.php
+++ b/Auth/OpenID/Consumer.php
@@ -347,7 +347,8 @@ class Auth_OpenID_Consumer {
         }
 
         if ($endpoint === null) {
-            return null;
+            return new Auth_OpenID_FailureResponse(null,
+              "Certificate or Certificate Authority verification failed");
         } else {
             return $this->beginWithoutDiscovery($endpoint,
                                                 $anonymous);


### PR DESCRIPTION
I suggest:

to let consumer::begin return `Auth_OpenID_FailureResponse` object with a meaningful error message text instead simply `null` when the underlying curl post or get fails due to certificate errors.
#### Purpose:

to signal when the `curl post` or `curl get` (in Yadis ParanoidHTTPFetcher.php) does not return a request object. For example, if Host certificate verification fails due to self-signed or untrusted CAs.

The current php-openid method Consumer::begin returns only a simple "null" upstream, my patch now returns the Auth_OpenID_FailureResponse with a message.

See also some lines below the patch: beginWithoutDiscovery already returns such an object in a similar way 

```return new Auth_OpenID_FailureResponse(null,
              "OpenID 1 requests MUST include the identifier " .
              "in the request.");

```

Patch works for me, but should be further tested in different environments to make sure that it does not break other code.
```
