### PR TITLE
fread() error in Auth/OpenID/FileStore.php line 309

### DIFF
--- a/Auth/OpenID/FileStore.php
+++ b/Auth/OpenID/FileStore.php
@@ -300,13 +300,22 @@ class Auth_OpenID_FileStore extends Auth_OpenID_OpenIDStore {
             return null;
         }
 
+        if (file_exists($filename) !== true) {
+            return null;
+        }
+
         $assoc_file = @fopen($filename, 'rb');
 
         if ($assoc_file === false) {
             return null;
         }
 
-        $assoc_s = fread($assoc_file, filesize($filename));
+        $filesize = filesize($filename);
+        if ($filesize === false || $filesize <= 0) {
+            return null;
+        }
+
+        $assoc_s = fread($assoc_file, $filesize);
         fclose($assoc_file);
 
         if (!$assoc_s) {


### PR DESCRIPTION
In some rare instances it could be that filesize() returns 0 resulting in fread() issuing an error.

This pull request includes a fix. Separate file_exists() and filesize() checks were added.
