### PR TITLE
Fixes #54. Pass request data to fix AX.

### DIFF
--- a/Auth/OpenID/Extension.php
+++ b/Auth/OpenID/Extension.php
@@ -39,7 +39,7 @@ class Auth_OpenID_Extension {
      *
      * Returns the message with the extension arguments added.
      */
-    function toMessage($message)
+    function toMessage($message, $request = null)
     {
         $implicit = $message->isOpenID1();
         $added = $message->namespaces->addAlias($this->ns_uri,
@@ -53,8 +53,13 @@ class Auth_OpenID_Extension {
             }
         }
 
-        $message->updateArgs($this->ns_uri,
-                             $this->getExtensionArgs());
+        if ($request !== null) {
+            $message->updateArgs($this->ns_uri,
+                                 $this->getExtensionArgs($request));
+        } else {
+            $message->updateArgs($this->ns_uri,
+                                 $this->getExtensionArgs());
+        }
         return $message;
     }
 }


### PR DESCRIPTION
AX fetch response is created based on AX fetch request data. Need to
pass the $request to the Auth_OpenID_AX_FetchResponse getExtensionArgs
method.
