### PR TITLE
Improves open_basedir detection

### DIFF
--- a/examples/detect.php
+++ b/examples/detect.php
@@ -352,7 +352,7 @@ function detect_stores($r, &$out)
     }
 
     $basedir_str = ini_get('open_basedir');
-    if (gettype($basedir_str) == 'string') {
+    if (gettype($basedir_str) == 'string' && $basedir_str) {
         $url = 'http://www.php.net/manual/en/features.safe-mode.php' .
             '#ini.open-basedir';
         $lnk = $r->link($url, 'open_basedir');


### PR DESCRIPTION
detect.php told me that open_basedir was active, but it isn't. This patch should fix that misinformation.

```
fredden@gordo:/tmp/php-openid/examples$ php detect.php | grep -C1 basedir 
If you are using a filesystem-based store or SQLite, be aware that
open_basedir
<http://www.php.net/manual/en/features.safe-mode.php#ini.open-basedir> is
in effect. This means that your data will have to be stored in one of the
fredden@gordo:/tmp/php-openid/examples$ php -i | grep basedir 
open_basedir => no value => no value
fredden@gordo:/tmp/php-openid/examples$ vi detect.php 
fredden@gordo:/tmp/php-openid/examples$ php detect.php | grep basedir 
The *open_basedir* configuration restriction is not in effect.
fredden@gordo:/tmp/php-openid/examples$ git diff detect.php 
diff --git a/examples/detect.php b/examples/detect.php
index 9c59db3..90e3995 100644
--- a/examples/detect.php
+++ b/examples/detect.php
@@ -352,7 +352,7 @@ function detect_stores($r, &$out)
     }

     $basedir_str = ini_get('open_basedir');
-    if (gettype($basedir_str) == 'string') {
+    if (gettype($basedir_str) == 'string' && $basedir_str) {
         $url = 'http://www.php.net/manual/en/features.safe-mode.php' .
             '#ini.open-basedir';
         $lnk = $r->link($url, 'open_basedir');
fredden@gordo:/tmp/php-openid/examples$
```
