### PR TITLE
Fixed wrong expiration command (expiresat -> expireat)

### DIFF
--- a/Auth/OpenID/PredisStore.php
+++ b/Auth/OpenID/PredisStore.php
@@ -77,8 +77,8 @@ class Auth_OpenID_PredisStore extends Auth_OpenID_OpenIDStore {
         $expiration = $this->redis->get($expirationKey);
         if (!$expiration || $newExpiration > $expiration) {
             $this->redis->set($expirationKey, $newExpiration);
-            $this->redis->expiresat($serverKey, $newExpiration);
-            $this->redis->expiresat($expirationKey, $newExpiration);
+            $this->redis->expireat($serverKey, $newExpiration);
+            $this->redis->expireat($expirationKey, $newExpiration);
         }
 
         // save association itself, will automatically expire


### PR DESCRIPTION
The committed and already merged `PredisStore` included a wrong expiration command. The correct command is [`EXPIREAT`](http://redis.io/commands/expireat) that is now fixed.
