### PR TITLE
Update Consumer.php

### DIFF
--- a/Auth/OpenID/Consumer.php
+++ b/Auth/OpenID/Consumer.php
@@ -616,6 +616,9 @@ class Auth_OpenID_GenericConsumer {
         $this->store = $store;
         $this->negotiator = Auth_OpenID_getDefaultNegotiator();
         $this->_use_assocs = (is_null($this->store) ? false : true);
+        if (get_class($this->store) == "Auth_OpenID_DumbStore") {
+            $this->_use_assocs = false;
+        }
 
         $this->fetcher = Auth_Yadis_Yadis::getHTTPFetcher();
 


### PR DESCRIPTION
```
$this->_use_assocs = (is_null($this->store) ? false : true);
```

always return true, even the store is Auth_OpenID_DumbStore, and do an association with the OpenID Server.

but OpenID Server will reject the check_authentication, if RP have do an association.
