### PR TITLE
Add Auth_OpenID_DISABLE_SSL_VERIFY opt to disable SSL verify

### DIFF
--- a/Auth/Yadis/ParanoidHTTPFetcher.php
+++ b/Auth/Yadis/ParanoidHTTPFetcher.php
@@ -80,7 +80,7 @@ class Auth_Yadis_ParanoidHTTPFetcher extends Auth_Yadis_HTTPFetcher {
         if (!$this->canFetchURL($url)) {
             return null;
         }
-       
+
         $stop = time() + $this->timeout;
         $off = $this->timeout;
 
@@ -98,7 +98,7 @@ class Auth_Yadis_ParanoidHTTPFetcher extends Auth_Yadis_HTTPFetcher {
             if ($c === false) {
                 Auth_OpenID::log(
                     "curl_init returned false; could not " .
-                    "initialize for URL '%s'", $url); 
+                    "initialize for URL '%s'", $url);
                 return null;
             }
 


### PR DESCRIPTION
Add option "Auth_OpenID_DISABLE_SSL_VERIFY" to disable SSL verify from curl_getinfo function. Please see error from http://stackoverflow.com/questions/13681621/http-fetching-failing-on-php-openid/21018104#21018104
