### PR TITLE
Yadis: drop custom replaceEntities() function and use html_entity_decode

### DIFF
--- a/Auth/Yadis/ParseHTML.php
+++ b/Auth/Yadis/ParseHTML.php
@@ -66,29 +66,6 @@ class Auth_Yadis_ParseHTML {
     }
 
     /**
-     * Replace HTML entities (amp, lt, gt, and quot) as well as
-     * numeric entities (e.g. #x9f;) with their actual values and
-     * return the new string.
-     *
-     * @access private
-     * @param string $str The string in which to look for entities
-     * @return string $new_str The new string entities decoded
-     */
-    function replaceEntities($str)
-    {
-        foreach ($this->_entity_replacements as $old => $new) {
-            $str = preg_replace(sprintf("/&%s;/", $old), $new, $str);
-        }
-
-        // Replace numeric entities because html_entity_decode doesn't
-        // do it for us.
-        $str = preg_replace('~&#x([0-9a-f]+);~ei', 'chr(hexdec("\\1"))', $str);
-        $str = preg_replace('~&#([0-9]+);~e', 'chr(\\1)', $str);
-
-        return $str;
-    }
-
-    /**
      * Strip single and double quotes off of a string, if they are
      * present.
      *
@@ -216,7 +193,7 @@ class Auth_Yadis_ParseHTML {
             $link_attrs = array();
             foreach ($attr_matches[0] as $index => $full_match) {
                 $name = $attr_matches[1][$index];
-                $value = $this->replaceEntities(
+                $value = html_entity_decode(
                               $this->removeQuotes($attr_matches[2][$index]));
 
                 $link_attrs[strtolower($name)] = $value;


### PR DESCRIPTION
Yadis' ParseHTML.php has a replaceEntities() function for replacing HTML entities, with a comment that appears to explain its existence by stating "Replace numeric entities because html_entity_decode doesn't do it for us". This is breaking with PHP 5.5 because it uses the deprecated /e modifier for preg_replace() - https://github.com/openid/php-openid/issues/108 . I think this custom function is no longer needed at least with PHP 5. PHP 5 has had support for replacing numeric entities since 2003, and its entity handling code has been refined quite a lot since then. replaceEntities() has been there since 2006, and probably earlier. I guess at that time PHP 4 compatibility was still important so this was needed - I don't think PHP 4's html_entity_decode() has ever had numeric entity support - but now PHP 5 is a decade old and there's a separate PHP 4 branch of php-openid, I think we can ditch replaceEntities() in the main branch!

It's a bit tricky running the test suite on a modern system, but I think I got it working well enough that the test that covers ParseHTML was working right. Without this patch it returns a bunch of 'EEEEEE' on my system (because of the preg_replace() /e modifier deprecation, I think); with this patch it runs without any 'EEE' type output, which I believe indicates that it passed. So I think that indicates the change is safe, but it'd be good if someone with more experience with php-openid's unit tests could verify.
