### PR TITLE
Reject OpenID XML responses with a doctype

### DIFF
--- a/Auth/Yadis/XML.php
+++ b/Auth/Yadis/XML.php
@@ -250,6 +250,10 @@ class Auth_Yadis_dom extends Auth_Yadis_XMLParser {
             return false;
         }
 
+        if (isset($this->doc->doctype)) {
+            return false;
+        }
+
         $this->xpath = new DOMXPath($this->doc);
 
         if ($this->xpath) {


### PR DESCRIPTION
To prevent potential malicious executions
