### PR TITLE
loop over directories "the right way"

### DIFF
--- a/Auth/OpenID/FileStore.php
+++ b/Auth/OpenID/FileStore.php
@@ -482,7 +482,7 @@ class Auth_OpenID_FileStore extends Auth_OpenID_OpenIDStore {
         }
 
         if ($handle = opendir($dir)) {
-            while ($item = readdir($handle)) {
+            while (false !== ($item = readdir($handle))) {
                 if (!in_array($item, array('.', '..'))) {
                     if (is_dir($dir . $item)) {
 


### PR DESCRIPTION
See http://php.net/manual/en/function.readdir.php - specifically

    /* This is the correct way to loop over the directory. */
    while (false !== ($entry = readdir($handle))) {
        echo "$entry\n";
    }

    /* This is the WRONG way to loop over the directory. */
    while ($entry = readdir($handle)) {
        echo "$entry\n";
    }

Looping over a directory the wrong way will cause the loop to stop if it comes to a directory named 0 (or anything else which evaluates to false)