### PR TITLE
PHP 7 compatibility

### DIFF
--- a/Auth/OpenID/AX.php
+++ b/Auth/OpenID/AX.php
@@ -69,7 +69,7 @@ function Auth_OpenID_AX_checkAlias($alias)
  * @package OpenID
  */
 class Auth_OpenID_AX_Error {
-    function Auth_OpenID_AX_Error($message=null)
+    function __construct($message=null)
     {
         $this->message = $message;
     }
@@ -151,7 +151,7 @@ class Auth_OpenID_AX_AttrInfo {
      * @param string $alias The name that should be given to this
      * attribute in the request.
      */
-    function Auth_OpenID_AX_AttrInfo($type_uri, $count, $required,
+    function __construct($type_uri, $count, $required,
                                      $alias)
     {
         /**
@@ -269,7 +269,7 @@ class Auth_OpenID_AX_FetchRequest extends Auth_OpenID_AX_Message {
 
     var $mode = 'fetch_request';
 
-    function Auth_OpenID_AX_FetchRequest($update_url=null)
+    function __construct($update_url=null)
     {
         /**
          * requested_attributes: The attributes that have been
@@ -540,7 +540,7 @@ class Auth_OpenID_AX_FetchRequest extends Auth_OpenID_AX_Message {
  */
 class Auth_OpenID_AX_KeyValueMessage extends Auth_OpenID_AX_Message {
 
-    function Auth_OpenID_AX_KeyValueMessage()
+    function __construct()
     {
         $this->data = array();
     }
@@ -793,9 +793,9 @@ class Auth_OpenID_AX_KeyValueMessage extends Auth_OpenID_AX_Message {
 class Auth_OpenID_AX_FetchResponse extends Auth_OpenID_AX_KeyValueMessage {
     var $mode = 'fetch_response';
 
-    function Auth_OpenID_AX_FetchResponse($update_url=null)
+    function __construct($update_url=null)
     {
-        $this->Auth_OpenID_AX_KeyValueMessage();
+        parent::__construct();
         $this->update_url = $update_url;
     }
 
@@ -990,7 +990,7 @@ class Auth_OpenID_AX_StoreResponse extends Auth_OpenID_AX_Message {
         return new Auth_OpenID_AX_StoreResponse($succeeded, $error_message);
     }
 
-    function Auth_OpenID_AX_StoreResponse($succeeded=true, $error_message=null)
+    function __construct($succeeded=true, $error_message=null)
     {
         if ($succeeded) {
             $this->mode = $this->SUCCESS_MODE;

--- a/Auth/OpenID/Association.php
+++ b/Auth/OpenID/Association.php
@@ -128,7 +128,7 @@ class Auth_OpenID_Association {
      * this time is 'HMAC-SHA1' and 'HMAC-SHA256', but new types may
      * be defined in the future.
      */
-    function Auth_OpenID_Association(
+    function __construct(
         $handle, $secret, $issued, $lifetime, $assoc_type)
     {
         if (!in_array($assoc_type,
@@ -523,7 +523,7 @@ function Auth_OpenID_getEncryptedNegotiator()
  * @package OpenID
  */
 class Auth_OpenID_SessionNegotiator {
-    function Auth_OpenID_SessionNegotiator($allowed_types)
+    function __construct($allowed_types)
     {
         $this->allowed_types = array();
         $this->setAllowedTypes($allowed_types);

--- a/Auth/OpenID/Consumer.php
+++ b/Auth/OpenID/Consumer.php
@@ -258,7 +258,7 @@ class Auth_OpenID_Consumer {
      * when creating the internal consumer object.  This is used for
      * testing.
      */
-    function Auth_OpenID_Consumer($store, $session = null,
+    function __construct($store, $session = null,
                                   $consumer_cls = null)
     {
         if ($session === null) {
@@ -456,7 +456,7 @@ class Auth_OpenID_DiffieHellmanSHA1ConsumerSession {
     var $secret_size = 20;
     var $allowed_assoc_types = array('HMAC-SHA1');
 
-    function Auth_OpenID_DiffieHellmanSHA1ConsumerSession($dh = null)
+    function __construct($dh = null)
     {
         if ($dh === null) {
             $dh = new Auth_OpenID_DiffieHellman();
@@ -611,7 +611,7 @@ class Auth_OpenID_GenericConsumer {
      * in the module description.  The default value is False, which
      * disables immediate mode.
      */
-    function Auth_OpenID_GenericConsumer($store)
+    function __construct($store)
     {
         $this->store = $store;
         $this->negotiator = Auth_OpenID_getDefaultNegotiator();
@@ -1757,7 +1757,7 @@ class Auth_OpenID_AuthRequest {
      * class.  Instances of this class are created by the library when
      * needed.
      */
-    function Auth_OpenID_AuthRequest($endpoint, $assoc)
+    function __construct($endpoint, $assoc)
     {
         $this->assoc = $assoc;
         $this->endpoint = $endpoint;
@@ -2036,7 +2036,7 @@ class Auth_OpenID_SuccessResponse extends Auth_OpenID_ConsumerResponse {
     /**
      * @access private
      */
-    function Auth_OpenID_SuccessResponse($endpoint, $message, $signed_args=null)
+    function __construct($endpoint, $message, $signed_args=null)
     {
         $this->endpoint = $endpoint;
         $this->identity_url = $endpoint->claimed_id;
@@ -2139,7 +2139,7 @@ class Auth_OpenID_SuccessResponse extends Auth_OpenID_ConsumerResponse {
 class Auth_OpenID_FailureResponse extends Auth_OpenID_ConsumerResponse {
     var $status = Auth_OpenID_FAILURE;
 
-    function Auth_OpenID_FailureResponse($endpoint, $message = null,
+    function __construct($endpoint, $message = null,
                                          $contact = null, $reference = null)
     {
         $this->setEndpoint($endpoint);
@@ -2164,7 +2164,7 @@ class Auth_OpenID_TypeURIMismatch extends Auth_OpenID_FailureResponse {
  * @package OpenID
  */
 class Auth_OpenID_ServerErrorContainer {
-    function Auth_OpenID_ServerErrorContainer($error_text,
+    function __construct($error_text,
                                               $error_code,
                                               $message)
     {
@@ -2202,7 +2202,7 @@ class Auth_OpenID_ServerErrorContainer {
 class Auth_OpenID_CancelResponse extends Auth_OpenID_ConsumerResponse {
     var $status = Auth_OpenID_CANCEL;
 
-    function Auth_OpenID_CancelResponse($endpoint)
+    function __construct($endpoint)
     {
         $this->setEndpoint($endpoint);
     }
@@ -2228,7 +2228,7 @@ class Auth_OpenID_CancelResponse extends Auth_OpenID_ConsumerResponse {
 class Auth_OpenID_SetupNeededResponse extends Auth_OpenID_ConsumerResponse {
     var $status = Auth_OpenID_SETUP_NEEDED;
 
-    function Auth_OpenID_SetupNeededResponse($endpoint,
+    function __construct($endpoint,
                                              $setup_url = null)
     {
         $this->setEndpoint($endpoint);

--- a/Auth/OpenID/DiffieHellman.php
+++ b/Auth/OpenID/DiffieHellman.php
@@ -47,7 +47,7 @@ class Auth_OpenID_DiffieHellman {
     var $private;
     var $lib = null;
 
-    function Auth_OpenID_DiffieHellman($mod = null, $gen = null,
+    function __construct($mod = null, $gen = null,
                                        $private = null, $lib = null)
     {
         if ($lib === null) {

--- a/Auth/OpenID/Discover.php
+++ b/Auth/OpenID/Discover.php
@@ -62,7 +62,7 @@ function Auth_OpenID_getOpenIDTypeName($type_uri) {
  * Object representing an OpenID service endpoint.
  */
 class Auth_OpenID_ServiceEndpoint {
-    function Auth_OpenID_ServiceEndpoint()
+    function __construct()
     {
         $this->claimed_id = null;
         $this->server_url = null;

--- a/Auth/OpenID/DumbStore.php
+++ b/Auth/OpenID/DumbStore.php
@@ -50,7 +50,7 @@ class Auth_OpenID_DumbStore extends Auth_OpenID_OpenIDStore {
      * @param string secret_phrase The phrase used to create the auth
      * key returned by getAuthKey
      */
-    function Auth_OpenID_DumbStore($secret_phrase)
+    function __construct($secret_phrase)
     {
         $this->auth_key = Auth_OpenID_SHA1($secret_phrase);
     }

--- a/Auth/OpenID/FileStore.php
+++ b/Auth/OpenID/FileStore.php
@@ -46,7 +46,7 @@ class Auth_OpenID_FileStore extends Auth_OpenID_OpenIDStore {
      * @param string $directory This is the directory to put the store
      * directories in.
      */
-    function Auth_OpenID_FileStore($directory)
+    function __construct($directory)
     {
         if (!Auth_OpenID::ensureDir($directory)) {
             trigger_error('Not a directory and failed to create: '

--- a/Auth/OpenID/MDB2Store.php
+++ b/Auth/OpenID/MDB2Store.php
@@ -62,7 +62,7 @@ class Auth_OpenID_MDB2Store extends Auth_OpenID_OpenIDStore {
      * the name of the table used for storing nonces.  The default
      * value is 'oid_nonces'.
      */
-    function Auth_OpenID_MDB2Store($connection,
+    function __construct($connection,
                                   $associations_table = null,
                                   $nonces_table = null)
     {

--- a/Auth/OpenID/MemcachedStore.php
+++ b/Auth/OpenID/MemcachedStore.php
@@ -41,7 +41,7 @@ class Auth_OpenID_MemcachedStore extends Auth_OpenID_OpenIDStore {
      *
      * @param resource connection Memcache connection resourse
      */
-    function Auth_OpenID_MemcachedStore($connection, $compress = false)
+    function __construct($connection, $compress = false)
     {
         $this->connection = $connection;
         $this->compress = $compress ? MEMCACHE_COMPRESSED : 0;

--- a/Auth/OpenID/Message.php
+++ b/Auth/OpenID/Message.php
@@ -127,7 +127,7 @@ class Auth_OpenID_Mapping {
      * Initialize a mapping.  If $classic_array is specified, its keys
      * and values are used to populate the mapping.
      */
-    function Auth_OpenID_Mapping($classic_array = null)
+    function __construct($classic_array = null)
     {
         $this->keys = array();
         $this->values = array();
@@ -274,7 +274,7 @@ class Auth_OpenID_Mapping {
  * @package OpenID
  */
 class Auth_OpenID_NamespaceMap {
-    function Auth_OpenID_NamespaceMap()
+    function __construct()
     {
         $this->alias_to_namespace = new Auth_OpenID_Mapping();
         $this->namespace_to_alias = new Auth_OpenID_Mapping();
@@ -414,7 +414,7 @@ class Auth_OpenID_NamespaceMap {
  */
 class Auth_OpenID_Message {
 
-    function Auth_OpenID_Message($openid_namespace = null)
+    function __construct($openid_namespace = null)
     {
         // Create an empty Message
         $this->allowed_openid_namespaces = array(

--- a/Auth/OpenID/PAPE.php
+++ b/Auth/OpenID/PAPE.php
@@ -37,7 +37,7 @@ class Auth_OpenID_PAPE_Request extends Auth_OpenID_Extension {
     var $ns_alias = 'pape';
     var $ns_uri = Auth_OpenID_PAPE_NS_URI;
 
-    function Auth_OpenID_PAPE_Request($preferred_auth_policies=null,
+    function __construct($preferred_auth_policies=null,
                                       $max_auth_age=null)
     {
         if ($preferred_auth_policies === null) {
@@ -161,7 +161,7 @@ class Auth_OpenID_PAPE_Response extends Auth_OpenID_Extension {
     var $ns_alias = 'pape';
     var $ns_uri = Auth_OpenID_PAPE_NS_URI;
 
-    function Auth_OpenID_PAPE_Response($auth_policies=null, $auth_time=null,
+    function __construct($auth_policies=null, $auth_time=null,
                                        $nist_auth_level=null)
     {
         if ($auth_policies) {

--- a/Auth/OpenID/Parse.php
+++ b/Auth/OpenID/Parse.php
@@ -108,7 +108,7 @@ class Auth_OpenID_Parse {
     var $_open_tag_expr = "<%s\b";
     var $_close_tag_expr = "<((\/%s\b)|(%s[^>\/]*\/))>";
 
-    function Auth_OpenID_Parse()
+    function __construct()
     {
         $this->_link_find = sprintf("/<link\b(?!:)([^>]*)(?!<)>/%s",
                                     $this->_re_flags);

--- a/Auth/OpenID/PredisStore.php
+++ b/Auth/OpenID/PredisStore.php
@@ -45,7 +45,7 @@ class Auth_OpenID_PredisStore extends Auth_OpenID_OpenIDStore {
      * @param \Predis\Client $redis  Predis client object
      * @param string         $prefix Prefix for all keys stored to the Redis
      */
-    function Auth_OpenID_PredisStore(\Predis\Client $redis, $prefix = '')
+    function __construct(\Predis\Client $redis, $prefix = '')
     {
         $this->prefix = $prefix;
         $this->redis = $redis;

--- a/Auth/OpenID/SQLStore.php
+++ b/Auth/OpenID/SQLStore.php
@@ -75,7 +75,7 @@ class Auth_OpenID_SQLStore extends Auth_OpenID_OpenIDStore {
      * the name of the table used for storing nonces.  The default
      * value is 'oid_nonces'.
      */
-    function Auth_OpenID_SQLStore($connection,
+    function __construct($connection,
                                   $associations_table = null,
                                   $nonces_table = null)
     {

--- a/Auth/OpenID/SReg.php
+++ b/Auth/OpenID/SReg.php
@@ -418,7 +418,7 @@ class Auth_OpenID_SRegResponse extends Auth_OpenID_SRegBase {
 
     var $ns_alias = 'sreg';
 
-    function Auth_OpenID_SRegResponse($data=null,
+    function __construct($data=null,
                                       $sreg_ns_uri=Auth_OpenID_SREG_NS_URI)
     {
         if ($data === null) {

--- a/Auth/OpenID/Server.php
+++ b/Auth/OpenID/Server.php
@@ -148,7 +148,7 @@ class Auth_OpenID_ServerError {
     /**
      * @access private
      */
-    function Auth_OpenID_ServerError($message = null, $text = null,
+    function __construct($message = null, $text = null,
                                      $reference = null, $contact = null)
     {
         $this->message = $message;
@@ -292,10 +292,10 @@ class Auth_OpenID_ServerError {
  * @package OpenID
  */
 class Auth_OpenID_NoReturnToError extends Auth_OpenID_ServerError {
-    function Auth_OpenID_NoReturnToError($message = null,
+    function __construct($message = null,
                                          $text = "No return_to URL available")
     {
-        parent::Auth_OpenID_ServerError($message, $text);
+        parent::__construct($message, $text);
     }
 
     function toString()
@@ -310,10 +310,10 @@ class Auth_OpenID_NoReturnToError extends Auth_OpenID_ServerError {
  * @package OpenID
  */
 class Auth_OpenID_MalformedReturnURL extends Auth_OpenID_ServerError {
-    function Auth_OpenID_MalformedReturnURL($message, $return_to)
+    function __construct($message, $return_to)
     {
         $this->return_to = $return_to;
-        parent::Auth_OpenID_ServerError($message, "malformed return_to URL");
+        parent::__construct($message, "malformed return_to URL");
     }
 }
 
@@ -323,10 +323,10 @@ class Auth_OpenID_MalformedReturnURL extends Auth_OpenID_ServerError {
  * @package OpenID
  */
 class Auth_OpenID_MalformedTrustRoot extends Auth_OpenID_ServerError {
-    function Auth_OpenID_MalformedTrustRoot($message = null,
+    function __construct($message = null,
                                             $text = "Malformed trust root")
     {
-        parent::Auth_OpenID_ServerError($message, $text);
+        parent::__construct($message, $text);
     }
 
     function toString()
@@ -353,7 +353,7 @@ class Auth_OpenID_CheckAuthRequest extends Auth_OpenID_Request {
     var $mode = "check_authentication";
     var $invalidate_handle = null;
 
-    function Auth_OpenID_CheckAuthRequest($assoc_handle, $signed,
+    function __construct($assoc_handle, $signed,
                                           $invalidate_handle = null)
     {
         $this->assoc_handle = $assoc_handle;
@@ -463,7 +463,7 @@ class Auth_OpenID_DiffieHellmanSHA1ServerSession {
     var $allowed_assoc_types = array('HMAC-SHA1');
     var $hash_func = 'Auth_OpenID_SHA1';
 
-    function Auth_OpenID_DiffieHellmanSHA1ServerSession($dh, $consumer_pubkey)
+    function __construct($dh, $consumer_pubkey)
     {
         $this->dh = $dh;
         $this->consumer_pubkey = $consumer_pubkey;
@@ -590,7 +590,7 @@ class Auth_OpenID_AssociateRequest extends Auth_OpenID_Request {
           'DH-SHA256' => 'Auth_OpenID_DiffieHellmanSHA256ServerSession');
     }
 
-    function Auth_OpenID_AssociateRequest($session, $assoc_type)
+    function __construct($session, $assoc_type)
     {
         $this->session = $session;
         $this->namespace = Auth_OpenID_OPENID2_NS;
@@ -763,7 +763,7 @@ class Auth_OpenID_CheckIDRequest extends Auth_OpenID_Request {
         }
     }
 
-    function Auth_OpenID_CheckIDRequest($identity, $return_to,
+    function __construct($identity, $return_to,
                                         $trust_root = null, $immediate = false,
                                         $assoc_handle = null, $server = null,
                                         $claimed_id = null)
@@ -1184,7 +1184,7 @@ class Auth_OpenID_CheckIDRequest extends Auth_OpenID_Request {
  */
 class Auth_OpenID_ServerResponse {
 
-    function Auth_OpenID_ServerResponse($request)
+    function __construct($request)
     {
         $this->request = $request;
         $this->fields = new Auth_OpenID_Message($this->request->namespace);
@@ -1271,7 +1271,7 @@ class Auth_OpenID_WebResponse {
     var $code = AUTH_OPENID_HTTP_OK;
     var $body = "";
 
-    function Auth_OpenID_WebResponse($code = null, $headers = null,
+    function __construct($code = null, $headers = null,
                                      $body = null)
     {
         if ($code) {
@@ -1311,7 +1311,7 @@ class Auth_OpenID_Signatory {
     /**
      * Create a new signatory using a given store.
      */
-    function Auth_OpenID_Signatory($store)
+    function __construct($store)
     {
         // assert store is not None
         $this->store = $store;
@@ -1483,7 +1483,7 @@ class Auth_OpenID_Encoder {
  */
 class Auth_OpenID_SigningEncoder extends Auth_OpenID_Encoder {
 
-    function Auth_OpenID_SigningEncoder($signatory)
+    function __construct($signatory)
     {
         $this->signatory = $signatory;
     }
@@ -1521,7 +1521,7 @@ class Auth_OpenID_SigningEncoder extends Auth_OpenID_Encoder {
  */
 class Auth_OpenID_Decoder {
 
-    function Auth_OpenID_Decoder($server)
+    function __construct($server)
     {
         $this->server = $server;
 
@@ -1604,9 +1604,11 @@ class Auth_OpenID_Decoder {
  * @package OpenID
  */
 class Auth_OpenID_EncodingError {
-    function Auth_OpenID_EncodingError($response)
+    function __construct($response = null)
     {
-        $this->response = $response;
+        if ($response !== null) {
+            $this->response = $response;
+        }
     }
 }
 
@@ -1616,7 +1618,7 @@ class Auth_OpenID_EncodingError {
  * @package OpenID
  */
 class Auth_OpenID_AlreadySigned extends Auth_OpenID_EncodingError {
-    // This response is already signed.
+
 }
 
 /**
@@ -1626,10 +1628,10 @@ class Auth_OpenID_AlreadySigned extends Auth_OpenID_EncodingError {
  * @package OpenID
  */
 class Auth_OpenID_UntrustedReturnURL extends Auth_OpenID_ServerError {
-    function Auth_OpenID_UntrustedReturnURL($message, $return_to,
+    function __construct($message, $return_to,
                                             $trust_root)
     {
-        parent::Auth_OpenID_ServerError($message, "Untrusted return_to URL");
+        parent::__construct($message, "Untrusted return_to URL");
         $this->return_to = $return_to;
         $this->trust_root = $trust_root;
     }
@@ -1679,7 +1681,7 @@ class Auth_OpenID_UntrustedReturnURL extends Auth_OpenID_ServerError {
  * @package OpenID
  */
 class Auth_OpenID_Server {
-    function Auth_OpenID_Server($store, $op_endpoint=null)
+    function __construct($store, $op_endpoint=null)
     {
         $this->store = $store;
         $this->signatory = new Auth_OpenID_Signatory($this->store);

--- a/Auth/OpenID/ServerRequest.php
+++ b/Auth/OpenID/ServerRequest.php
@@ -28,7 +28,7 @@ require_once "Auth/OpenID.php";
  * @package OpenID
  */
 class Auth_OpenID_ServerRequest {
-    function Auth_OpenID_ServerRequest()
+    function __construct()
     {
         $this->mode = null;
     }

--- a/Auth/Yadis/HTTPFetcher.php
+++ b/Auth/Yadis/HTTPFetcher.php
@@ -23,7 +23,7 @@ define('Auth_OpenID_USER_AGENT',
        'php-openid/'.Auth_OpenID_VERSION.' (php/'.phpversion().')');
 
 class Auth_Yadis_HTTPResponse {
-    function Auth_Yadis_HTTPResponse($final_url = null, $status = null,
+    function __construct($final_url = null, $status = null,
                                          $headers = null, $body = null)
     {
         $this->final_url = $final_url;

--- a/Auth/Yadis/Manager.php
+++ b/Auth/Yadis/Manager.php
@@ -280,7 +280,7 @@ class Auth_Yadis_Manager {
      *
      * @access private
      */
-    function Auth_Yadis_Manager($starting_url, $yadis_url,
+    function __construct($starting_url, $yadis_url,
                                     $services, $session_key)
     {
         // The URL that was used to initiate the Yadis protocol
@@ -387,7 +387,7 @@ class Auth_Yadis_Discovery {
      * @param string $session_key_suffix The optional session key
      * suffix override.
      */
-    function Auth_Yadis_Discovery($session, $url,
+    function __construct($session, $url,
                                       $session_key_suffix = null)
     {
         /// Initialize a discovery object

--- a/Auth/Yadis/ParanoidHTTPFetcher.php
+++ b/Auth/Yadis/ParanoidHTTPFetcher.php
@@ -27,7 +27,7 @@ require_once "Auth/OpenID.php";
  * @package OpenID
  */
 class Auth_Yadis_ParanoidHTTPFetcher extends Auth_Yadis_HTTPFetcher {
-    function Auth_Yadis_ParanoidHTTPFetcher()
+    function __construct()
     {
         $this->reset();
     }

--- a/Auth/Yadis/ParseHTML.php
+++ b/Auth/Yadis/ParseHTML.php
@@ -43,7 +43,7 @@ class Auth_Yadis_ParseHTML {
      */
     var $_attr_find = '\b([-\w]+)=(".*?"|\'.*?\'|.+?)[\/\s>]';
 
-    function Auth_Yadis_ParseHTML()
+    function __construct()
     {
         $this->_attr_find = sprintf("/%s/%s",
                                     $this->_attr_find,

--- a/Auth/Yadis/XML.php
+++ b/Auth/Yadis/XML.php
@@ -134,7 +134,7 @@ class Auth_Yadis_XMLParser {
  * @package OpenID
  */
 class Auth_Yadis_domxml extends Auth_Yadis_XMLParser {
-    function Auth_Yadis_domxml()
+    function __construct()
     {
         $this->xml = null;
         $this->doc = null;
@@ -217,7 +217,7 @@ class Auth_Yadis_domxml extends Auth_Yadis_XMLParser {
  * @package OpenID
  */
 class Auth_Yadis_dom extends Auth_Yadis_XMLParser {
-    function Auth_Yadis_dom()
+    function __construct()
     {
         $this->xml = null;
         $this->doc = null;

--- a/Auth/Yadis/XRDS.php
+++ b/Auth/Yadis/XRDS.php
@@ -85,7 +85,7 @@ class Auth_Yadis_Service {
     /**
      * Creates an empty service object.
      */
-    function Auth_Yadis_Service()
+    function __construct()
     {
         $this->element = null;
         $this->parser = null;
@@ -255,7 +255,7 @@ class Auth_Yadis_XRDS {
      * Instantiate a Auth_Yadis_XRDS object.  Requires an XPath
      * instance which has been used to parse a valid XRDS document.
      */
-    function Auth_Yadis_XRDS($xmlParser, $xrdNodes)
+    function __construct($xmlParser, $xrdNodes)
     {
         $this->parser = $xmlParser;
         $this->xrdNode = $xrdNodes[count($xrdNodes) - 1];

--- a/Auth/Yadis/XRIRes.php
+++ b/Auth/Yadis/XRIRes.php
@@ -8,7 +8,7 @@ require_once 'Auth/Yadis/XRDS.php';
 require_once 'Auth/Yadis/XRI.php';
 
 class Auth_Yadis_ProxyResolver {
-    function Auth_Yadis_ProxyResolver($fetcher, $proxy_url = null)
+    function __construct($fetcher, $proxy_url = null)
     {
         $this->fetcher = $fetcher;
         $this->proxy_url = $proxy_url;

--- a/Auth/Yadis/Yadis.php
+++ b/Auth/Yadis/Yadis.php
@@ -68,7 +68,7 @@ class Auth_Yadis_DiscoveryResult {
     // Did the discovery fail miserably?
     var $failed = false;
 
-    function Auth_Yadis_DiscoveryResult($request_uri)
+    function __construct($request_uri)
     {
         // Initialize the state of the object
         // sets all attributes to None except the request_uri

--- a/Tests/Auth/OpenID/AX.php
+++ b/Tests/Auth/OpenID/AX.php
@@ -517,7 +517,7 @@ class FetchRequestTest extends PHPUnit_Framework_TestCase {
 }
 
 class FauxEndpoint {
-    function FauxEndpoint() {
+    function __construct() {
         $this->claimed_id = 'http://some.url/';
     }
 }
@@ -777,7 +777,7 @@ class Tests_Auth_OpenID_AX extends PHPUnit_Framework_TestSuite {
         return "Tests_Auth_OpenID_AX";
     }
 
-    function Tests_Auth_OpenID_AX()
+    function __construct()
     {
         $this->addTestSuite('StoreResponseTest');
         $this->addTestSuite('StoreRequestTest');

--- a/Tests/Auth/OpenID/AssociationResponse.php
+++ b/Tests/Auth/OpenID/AssociationResponse.php
@@ -118,7 +118,7 @@ class TestExtractAssociationMissingFieldsOpenID1 extends Tests_Auth_OpenID_Assoc
 }
 
 class DummyAssocationSession {
-    function DummyAssocationSession($session_type, $allowed_assoc_types=array())
+    function __construct($session_type, $allowed_assoc_types=array())
     {
         $this->session_type = $session_type;
         $this->allowed_assoc_types = $allowed_assoc_types;

--- a/Tests/Auth/OpenID/AuthRequest.php
+++ b/Tests/Auth/OpenID/AuthRequest.php
@@ -288,7 +288,7 @@ class Tests_Auth_OpenID_AuthRequest extends PHPUnit_Framework_TestSuite {
         return "Tests_Auth_OpenID_AuthRequest";
     }
 
-    function Tests_Auth_OpenID_AuthRequest()
+    function __construct()
     {
         $this->addTestSuite('TestAuthRequestOpenID1');
         $this->addTestSuite('TestAuthRequestOpenID1Immediate');

--- a/Tests/Auth/OpenID/BigMath.php
+++ b/Tests/Auth/OpenID/BigMath.php
@@ -20,7 +20,7 @@ class Tests_Auth_OpenID_BinLongConvertRnd extends PHPUnit_Framework_TestCase {
     var $lib;
     var $max;
 
-    function Tests_Auth_OpenID_BinLongConvertRnd($lib, $max)
+    function __construct($lib, $max)
     {
         $this->lib =& $lib;
         $this->max = $max;
@@ -45,7 +45,7 @@ class Tests_Auth_OpenID_BinLongConvert extends PHPUnit_Framework_TestCase {
     var $bin;
     var $lng;
 
-    function Tests_Auth_OpenID_BinLongConvert($lib, $bin, $lng)
+    function __construct($lib, $bin, $lng)
     {
         $this->lib =& $lib;
         $this->bin = $bin;
@@ -66,7 +66,7 @@ class Tests_Auth_OpenID_Base64ToLong extends PHPUnit_Framework_TestCase {
     var $b64;
     var $lib;
 
-    function Tests_Auth_OpenID_Base64ToLong($lib, $b64, $num)
+    function __construct($lib, $b64, $num)
     {
         $this->lib = $lib;
         $this->b64 = $b64;
@@ -81,7 +81,7 @@ class Tests_Auth_OpenID_Base64ToLong extends PHPUnit_Framework_TestCase {
 }
 
 class Tests_Auth_OpenID_LongToBase64 extends Tests_Auth_OpenID_Base64ToLong {
-    function Tests_Auth_OpenID_LongToBase64($lib, $b64, $num)
+    function __construct($lib, $b64, $num)
     {
         $this->lib = $lib;
         $this->b64 = $b64;
@@ -96,7 +96,7 @@ class Tests_Auth_OpenID_LongToBase64 extends Tests_Auth_OpenID_Base64ToLong {
 }
 
 class Tests_Auth_OpenID_Rand extends PHPUnit_Framework_TestCase {
-    function Tests_Auth_OpenID_Rand($lib)
+    function __construct($lib)
     {
         $this->lib =& $lib;
     }
@@ -216,7 +216,7 @@ class Tests_Auth_OpenID_BigMath extends PHPUnit_Framework_TestSuite {
 
     }
 
-    function Tests_Auth_OpenID_BigMath($name)
+    function __construct($name)
     {
         $this->setName($name);
 

--- a/Tests/Auth/OpenID/Consumer.php
+++ b/Tests/Auth/OpenID/Consumer.php
@@ -41,7 +41,7 @@ function mkSuccess($endpoint, $q)
 }
 
 class FastConsumerSession extends Auth_OpenID_DiffieHellmanSHA1ConsumerSession {
-    function FastConsumerSession($dh = null)
+    function __construct($dh = null)
     {
         if ($dh === null) {
             $dh = new Auth_OpenID_DiffieHellman(100389557, 2);
@@ -108,7 +108,7 @@ function Auth_OpenID_associate($qs, $assoc_secret, $assoc_handle)
 }
 
 class Auth_OpenID_TestFetcher extends Auth_Yadis_HTTPFetcher {
-    function Auth_OpenID_TestFetcher($user_url, $user_page,
+    function __construct($user_url, $user_page,
                                      $assoc_secret, $assoc_handle)
     {
         $this->get_responses = array($user_url =>
@@ -992,7 +992,7 @@ class Tests_Auth_OpenID_Consumer_TestCheckAuthTriggered extends _TestIdRes {
 }
 
 class _MockFetcher {
-    function _MockFetcher($response = null)
+    function __construct($response = null)
     {
         // response is (code, url, body)
         $this->response = $response;
@@ -1519,6 +1519,9 @@ class _BadArgCheckingConsumer extends Auth_OpenID_GenericConsumer {
 }
 
 class Tests_Auth_OpenID_Consumer_TestCheckAuth extends _TestIdRes {
+    public $fetcher;
+    public $consumer;
+
     function setUp()
     {
         $this->store = new Tests_Auth_OpenID_MemStore();
@@ -1608,6 +1611,8 @@ class Tests_Auth_OpenID_Consumer_TestCheckAuth extends _TestIdRes {
 }
 
 class Tests_Auth_OpenID_Consumer_TestFetchAssoc extends PHPUnit_Framework_TestCase {
+    public $fetcher;
+    public $consumer;
     function setUp()
     {
         $this->store = new Tests_Auth_OpenID_MemStore();
@@ -1781,7 +1786,7 @@ class Tests_Auth_OpenID_SuccessResponse extends PHPUnit_Framework_TestCase {
 }
 
 class _StubConsumer {
-    function _StubConsumer()
+    function __construct()
     {
         $this->assoc = null;
         $this->response = null;
@@ -2069,6 +2074,9 @@ class IDPDrivenTest_Consumer2 extends ConfigurableConsumer {
 }
 
 class IDPDrivenTest extends PHPUnit_Framework_TestCase {
+    public $consumer;
+    public $endpoint;
+
     function setUp()
     {
         $this->store = new GoodAssocStore();

--- a/Tests/Auth/OpenID/DiffieHellman.php
+++ b/Tests/Auth/OpenID/DiffieHellman.php
@@ -18,7 +18,7 @@ require_once 'Auth/OpenID/DiffieHellman.php';
 require_once 'Tests/Auth/OpenID/TestUtil.php';
 
 class Tests_Auth_OpenID_DiffieHellman_CheckCases extends PHPUnit_Framework_TestCase {
-    function Tests_Auth_OpenID_DiffieHellman_CheckCases($cases, $n)
+    function __construct($cases, $n)
     {
         $this->cases = $cases;
         $this->n = $n;
@@ -31,7 +31,7 @@ class Tests_Auth_OpenID_DiffieHellman_CheckCases extends PHPUnit_Framework_TestC
 }
 
 class Tests_Auth_OpenID_DiffieHellman_Private extends PHPUnit_Framework_TestCase {
-    function Tests_Auth_OpenID_DiffieHellman_Private($name, $input, $expected)
+    function __construct($name, $input, $expected)
     {
         $this->setName("$name");
         $this->input = $input;
@@ -47,7 +47,7 @@ class Tests_Auth_OpenID_DiffieHellman_Private extends PHPUnit_Framework_TestCase
 }
 
 class Tests_Auth_OpenID_DiffieHellman_Exch extends PHPUnit_Framework_TestCase {
-    function Tests_Auth_OpenID_DiffieHellman_Exch($name, $p1, $p2, $shared)
+    function __construct($name, $p1, $p2, $shared)
     {
         $this->setName("$name");
         $this->p1 = $p1;
@@ -114,7 +114,7 @@ class Tests_Auth_OpenID_DiffieHellman extends PHPUnit_Framework_TestSuite {
         return $cases;
     }
 
-    function Tests_Auth_OpenID_DiffieHellman($name)
+    function __construct($name)
     {
         $this->setName($name);
 

--- a/Tests/Auth/OpenID/Discover_OpenID.php
+++ b/Tests/Auth/OpenID/Discover_OpenID.php
@@ -13,7 +13,7 @@ require_once 'Auth/Yadis/XRI.php';
  */
 
 class _SimpleMockFetcher {
-    function _SimpleMockFetcher($responses)
+    function __construct($responses)
     {
         $this->responses = $responses;
     }
@@ -60,7 +60,7 @@ class Tests_Auth_OpenID_ServiceEndpoint extends PHPUnit_Framework_TestCase {
 
 class Tests_Auth_OpenID_DiscoveryFailure extends PHPUnit_Framework_TestCase {
 
-    function Tests_Auth_OpenID_DiscoveryFailure($responses)
+    function __construct($responses)
     {
         // Response is ($code, $url, $body).
         $this->cases = array(
@@ -97,7 +97,7 @@ class Tests_Auth_OpenID_DiscoveryFailure extends PHPUnit_Framework_TestCase {
 class _ErrorRaisingFetcher {
     // Just raise an exception when fetch is called
 
-    function _ErrorRaisingFetcher($thing_to_raise)
+    function __construct($thing_to_raise)
     {
         $this->thing_to_raise = $thing_to_raise;
     }
@@ -123,7 +123,7 @@ class Tests_Auth_OpenID_Discover_FetchException extends PHPUnit_Framework_TestCa
     // Make sure exceptions get passed through discover function from
     // fetcher.
 
-    function Tests_Auth_OpenID_Discover_FetchException($exc)
+    function __construct($exc)
     {
         $this->cases = array(E_AUTH_OPENID_EXCEPTION,
                              E_AUTH_OPENID_DIDFETCH,
@@ -151,7 +151,7 @@ class Tests_Auth_OpenID_Discover_FetchException extends PHPUnit_Framework_TestCa
 // Tests for openid.consumer.discover.discover
 
 class _DiscoveryMockFetcher extends Auth_Yadis_HTTPFetcher {
-    function _DiscoveryMockFetcher($documents)
+    function __construct($documents)
     {
         $this->redirect = null;
         $this->documents = $documents;
@@ -536,7 +536,7 @@ class Tests_Auth_OpenID_Discover_OpenID extends _DiscoveryBase {
 
 class _MockFetcherForXRIProxy extends Auth_Yadis_HTTPFetcher {
 
-    function _MockFetcherForXRIProxy($documents)
+    function __construct($documents)
     {
         $this->documents = $documents;
         $this->fetchlog = array();
@@ -634,7 +634,7 @@ class TestXRIDiscovery extends _DiscoveryBase {
 }
 
 class Tests_Auth_OpenID_DiscoverSession {
-    function Tests_Auth_OpenID_DiscoverSession()
+    function __construct()
     {
         $this->data = array();
     }
@@ -686,10 +686,10 @@ class _FetcherWithoutSSL extends _DiscoveryMockFetcher {
 class _NonFetcher extends _DiscoveryMockFetcher {
     var $used = false;
 
-    function _NonFetcher()
+    function __construct()
     {
         $a = array();
-        parent::_DiscoveryMockFetcher($a);
+        parent::__construct($a);
     }
 
     function supportsSSL()

--- a/Tests/Auth/OpenID/HMAC.php
+++ b/Tests/Auth/OpenID/HMAC.php
@@ -18,7 +18,7 @@ require_once 'Auth/OpenID/HMAC.php';
 require_once 'Tests/Auth/OpenID/TestUtil.php';
 
 class Tests_Auth_OpenID_HMAC_TestCase extends PHPUnit_Framework_TestCase {
-    function Tests_Auth_OpenID_HMAC_TestCase(
+    function __construct(
         $name, $key, $data, $expected, $hmac_func)
     {
 
@@ -131,7 +131,7 @@ class Tests_Auth_OpenID_HMAC extends PHPUnit_Framework_TestSuite {
         return $final;
     }
 
-    function Tests_Auth_OpenID_HMAC($name)
+    function __construct($name)
     {
         $this->setName($name);
         $hash_test_defs = array(array(

--- a/Tests/Auth/OpenID/KVForm.php
+++ b/Tests/Auth/OpenID/KVForm.php
@@ -55,7 +55,7 @@ class Tests_Auth_OpenID_KVForm_TestCase extends PHPUnit_Framework_TestCase {
 
 class Tests_Auth_OpenID_KVForm_TestCase_Parse
 extends Tests_Auth_OpenID_KVForm_TestCase {
-    function Tests_Auth_OpenID_KVForm_TestCase_Parse(
+    function __construct(
         $arr, $str, $lossy, $errs)
     {
 
@@ -97,7 +97,7 @@ extends Tests_Auth_OpenID_KVForm_TestCase {
 
 class Tests_Auth_OpenID_KVForm_TestCase_Null
 extends Tests_Auth_OpenID_KVForm_TestCase {
-    function Tests_Auth_OpenID_KVForm_TestCase_Null($arr, $errs)
+    function __construct($arr, $errs)
     {
         $this->arr = $arr;
         $this->errs = $errs;
@@ -112,7 +112,7 @@ extends Tests_Auth_OpenID_KVForm_TestCase {
 }
 
 class Tests_Auth_OpenID_KVForm extends PHPUnit_Framework_TestSuite {
-    function Tests_Auth_OpenID_KVForm($name)
+    function __construct($name)
     {
         $this->setName($name);
         $testdata_list = array(

--- a/Tests/Auth/OpenID/MemStore.php
+++ b/Tests/Auth/OpenID/MemStore.php
@@ -7,7 +7,7 @@ require_once "Auth/OpenID/Interface.php";
 require_once 'Auth/OpenID/Nonce.php';
 
 class ServerAssocs {
-    function ServerAssocs()
+    function __construct()
     {
         $this->assocs = array();
     }
@@ -76,7 +76,7 @@ class ServerAssocs {
  * Use for single long-running processes.  No persistence supplied.
  */
 class Tests_Auth_OpenID_MemStore extends Auth_OpenID_OpenIDStore {
-    function Tests_Auth_OpenID_MemStore()
+    function __construct()
     {
         $this->server_assocs = array();
         $this->nonces = array();

--- a/Tests/Auth/OpenID/Negotiation.php
+++ b/Tests/Auth/OpenID/Negotiation.php
@@ -336,7 +336,7 @@ class Tests_Auth_OpenID_Negotiation extends PHPUnit_Framework_TestSuite {
         return 'Tests_Auth_OpenID_Negotiation';
     }
 
-    function Tests_Auth_OpenID_Negotiation()
+    function __construct()
     {
         $this->addTestSuite('TestNegotiatorBehaviors');
         $this->addTestSuite('TestOpenID1SessionNegotiation');

--- a/Tests/Auth/OpenID/Nonce.php
+++ b/Tests/Auth/OpenID/Nonce.php
@@ -19,7 +19,7 @@ define('Tests_Auth_OpenID_nonce_re',
        '/\A\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\dZ/');
 
 class Tests_Auth_OpenID_Nonce extends PHPUnit_Framework_TestSuite {
-    function Tests_Auth_OpenID_Nonce()
+    function __construct()
     {
         $this->addTestSuite('Tests_Auth_OpenID_NonceTests');
         $this->makeSplitTests();
@@ -95,7 +95,7 @@ class Tests_Auth_OpenID_Nonce extends PHPUnit_Framework_TestSuite {
 }
 
 class Tests_Auth_OpenID_Nonce_TimestampCase extends PHPUnit_Framework_TestCase {
-    function Tests_Auth_OpenID_Nonce_TimestampCase(
+    function __construct(
         $nonce_str, $skew, $now, $expected)
     {
         $this->nonce_string = $nonce_str;
@@ -151,7 +151,7 @@ class Tests_Auth_OpenID_NonceTests extends PHPUnit_Framework_TestCase {
 }
 
 class Tests_Auth_OpenID_Nonce_BadSplitCase extends PHPUnit_Framework_TestCase {
-    function Tests_Auth_OpenID_Nonce_BadSplitCase($nonce_str)
+    function __construct($nonce_str)
     {
         $this->nonce_str = $nonce_str;
     }

--- a/Tests/Auth/OpenID/OpenID_Yadis.php
+++ b/Tests/Auth/OpenID/OpenID_Yadis.php
@@ -141,7 +141,7 @@ function __subsets($list)
 }
 
 class Tests_Auth_OpenID_Tester extends PHPUnit_Framework_TestCase {
-    function Tests_Auth_OpenID_Tester($uris, $type_uris, $delegate)
+    function __construct($uris, $type_uris, $delegate)
     {
         parent::__construct();
         $this->uris = $uris;
@@ -211,7 +211,7 @@ class Tests_Auth_OpenID_Tester extends PHPUnit_Framework_TestCase {
 }
 
 class Tests_Auth_OpenID_OpenID_Yadis extends PHPUnit_Framework_TestSuite {
-    function Tests_Auth_OpenID_OpenID_Yadis()
+    function __construct()
     {
         global $__data;
         foreach ($__data as $case) {

--- a/Tests/Auth/OpenID/PAPE.php
+++ b/Tests/Auth/OpenID/PAPE.php
@@ -93,7 +93,7 @@ class PapeRequestTestCase extends PHPUnit_Framework_TestCase {
 }
 
 class PAPE_DummySuccessResponse {
-  function PAPE_DummySuccessResponse($message, $signed_stuff)
+  function __construct($message, $signed_stuff)
   {
     $this->message = $message;
     $this->signed_stuff = $signed_stuff;
@@ -235,7 +235,7 @@ class Tests_Auth_OpenID_PAPE extends PHPUnit_Framework_TestSuite {
     return "Tests_Auth_OpenID_PAPE";
   }
 
-  function Tests_Auth_OpenID_PAPE() {
+  function __construct() {
     $this->addTestSuite('PapeRequestTestCase');
     $this->addTestSuite('PapeResponseTestCase');
   }

--- a/Tests/Auth/OpenID/Parse.php
+++ b/Tests/Auth/OpenID/Parse.php
@@ -17,7 +17,7 @@ require_once 'Tests/Auth/OpenID/TestUtil.php';
 require_once 'Auth/OpenID/Parse.php';
 
 class Tests_Auth_OpenID_Link extends PHPUnit_Framework_TestCase {
-    function Tests_Auth_OpenID_Link($case)
+    function __construct($case)
     {
         list($desc, $markup, $links, $case_text) = $case;
         $this->desc = $desc;
@@ -85,7 +85,7 @@ class Tests_Auth_OpenID_Link extends PHPUnit_Framework_TestCase {
 }
 
 class NumTestCases extends PHPUnit_Framework_TestCase {
-    function NumTestCases($test_cases, $num_tests)
+    function __construct($test_cases, $num_tests)
     {
         $this->test_cases = $test_cases;
         $this->num_tests = $num_tests;
@@ -168,7 +168,7 @@ class Tests_Auth_OpenID_Parse extends PHPUnit_Framework_TestSuite {
         return array($num_tests, $tests);
     }
 
-    function Tests_Auth_OpenID_Parse()
+    function __construct()
     {
         $test_data = Tests_Auth_OpenID_readdata('linkparse.txt');
 

--- a/Tests/Auth/OpenID/RPVerify.php
+++ b/Tests/Auth/OpenID/RPVerify.php
@@ -45,7 +45,7 @@ class Tests_Auth_OpenID_BuildDiscoveryURL extends PHPUnit_Framework_TestCase {
 }
 
 class _MockDiscover {
-    function _MockDiscover($data) {
+    function __construct($data) {
         $this->data =& $data;
     }
 
@@ -219,7 +219,7 @@ class Tests_Auth_OpenID_ReturnToMatches extends PHPUnit_Framework_TestCase {
 }
 
 class Verifier {
-    function Verifier($test_case, $return_to)
+    function __construct($test_case, $return_to)
     {
         $this->tc =& $test_case;
         $this->return_to = $return_to;
@@ -281,7 +281,7 @@ class Tests_Auth_OpenID_RPVerify extends PHPUnit_Framework_TestSuite {
         return "Tests_Auth_OpenID_RPVerify";
     }
 
-    function Tests_Auth_OpenID_RPVerify()
+    function __construct()
     {
         $this->addTestSuite('Tests_Auth_OpenID_VerifyReturnTo');
         $this->addTestSuite('Tests_Auth_OpenID_ReturnToMatches');

--- a/Tests/Auth/OpenID/SReg.php
+++ b/Tests/Auth/OpenID/SReg.php
@@ -39,7 +39,7 @@ class CheckFieldNameTest extends PHPUnit_Framework_TestCase {
 
 // For supportsSReg test
 class FakeEndpoint {
-    function FakeEndpoint($supported)
+    function __construct($supported)
     {
         $this->supported = $supported;
         $this->checked_uris = array();
@@ -81,7 +81,7 @@ class SupportsSRegTest extends PHPUnit_Framework_TestCase {
 }
 
 class FakeMessage {
-    function FakeMessage()
+    function __construct()
     {
         $this->openid1 = false;
         $this->namespaces = new Auth_OpenID_NamespaceMap();
@@ -180,7 +180,7 @@ $__args_sentinel = 'args_sentinel';
 $__ns_sentinel = 'ns_sentinel';
 
 class SentinelFakeMessage {
-    function SentinelFakeMessage($test_case)
+    function __construct($test_case)
     {
         $this->test_case =& $test_case;
         $this->message = new Auth_OpenID_Message();
@@ -559,7 +559,7 @@ class SRegRequestTest extends PHPUnit_Framework_TestCase {
 }
 
 class DummySuccessResponse {
-    function DummySuccessResponse($message, $signed_stuff)
+    function __construct($message, $signed_stuff)
     {
         $this->message = $message;
         $this->signed_stuff = $signed_stuff;
@@ -658,7 +658,7 @@ class Tests_Auth_OpenID_SReg extends PHPUnit_Framework_TestSuite {
         return "Tests_Auth_OpenID_SReg";
     }
 
-    function Tests_Auth_OpenID_SReg()
+    function __construct()
     {
         $this->addTestSuite('SRegURITest');
         $this->addTestSuite('CheckFieldNameTest');

--- a/Tests/Auth/OpenID/Server.php
+++ b/Tests/Auth/OpenID/Server.php
@@ -1532,7 +1532,7 @@ class Tests_Auth_OpenID_CheckIDExtension extends PHPUnit_Framework_TestCase {
 class _MockSignatory {
     var $isValid = true;
 
-    function _MockSignatory($assoc)
+    function __construct($assoc)
     {
         $this->assocs = array($assoc);
     }
@@ -2019,7 +2019,7 @@ class Tests_Auth_OpenID_Associate extends PHPUnit_Framework_TestCase {
 }
 
 class Counter {
-    function Counter()
+    function __construct()
     {
         $this->count = 0;
     }
@@ -2442,7 +2442,7 @@ class Tests_Auth_OpenID_Server extends PHPUnit_Framework_TestSuite {
         return "Tests_Auth_OpenID_Server";
     }
 
-    function Tests_Auth_OpenID_Server()
+    function __construct()
     {
         $this->addTestSuite('Tests_Auth_OpenID_Signatory');
         $this->addTestSuite('Tests_Auth_OpenID_ServerTest');

--- a/Tests/Auth/OpenID/StoreTest.php
+++ b/Tests/Auth/OpenID/StoreTest.php
@@ -696,7 +696,7 @@ class Tests_Auth_OpenID_Included_StoreTest extends Tests_Auth_OpenID_Store {
 
         $db->query("USE $temp_db_name");
 
-        $store =& new Auth_OpenID_MDB2Store($db);
+        $store = new Auth_OpenID_MDB2Store($db);
         if (!$store->createTables()) {
             $this->fail("Failed to create tables");
             return;
@@ -751,7 +751,7 @@ class Tests_Auth_OpenID_StoreTest extends PHPUnit_Framework_TestSuite {
         return "Tests_Auth_OpenID_StoreTest";
     }
 
-      function Tests_Auth_OpenID_StoreTest()
+      function __construct()
     {
         $this->addTestSuite('Tests_Auth_OpenID_Included_StoreTest');
         $this->addTestSuite('Tests_Auth_OpenID_MemcachedStore_Test');

--- a/Tests/Auth/OpenID/TrustRoot.php
+++ b/Tests/Auth/OpenID/TrustRoot.php
@@ -8,7 +8,7 @@ require_once "Auth/OpenID/TrustRoot.php";
 require_once "Tests/Auth/OpenID/TestUtil.php";
 
 class Tests_Auth_OpenID_TRParseCase extends PHPUnit_Framework_TestCase {
-    function Tests_Auth_OpenID_TRParseCase($desc, $case, $expected)
+    function __construct($desc, $case, $expected)
     {
         $this->setName($desc);
         $this->case = $case;
@@ -36,7 +36,7 @@ class Tests_Auth_OpenID_TRParseCase extends PHPUnit_Framework_TestCase {
 }
 
 class Tests_Auth_OpenID_TRMatchCase extends PHPUnit_Framework_TestCase {
-    function Tests_Auth_OpenID_TRMatchCase($desc, $tr, $rt, $matches)
+    function __construct($desc, $tr, $rt, $matches)
     {
         $this->setName($desc);
         $this->tr = $tr;
@@ -155,7 +155,7 @@ function Tests_Auth_OpenID_trustRootTests()
 }
 
 class Tests_Auth_OpenID_TrustRoot extends PHPUnit_Framework_TestSuite {
-    function Tests_Auth_OpenID_TrustRoot($name)
+    function __construct($name)
     {
         $this->setName($name);
 

--- a/Tests/Auth/OpenID/URINorm.php
+++ b/Tests/Auth/OpenID/URINorm.php
@@ -18,7 +18,7 @@ require_once 'Auth/OpenID/URINorm.php';
 require_once 'Tests/Auth/OpenID/TestUtil.php';
 
 class Tests_Auth_OpenID_URINorm_TestCase extends PHPUnit_Framework_TestCase {
-    function Tests_Auth_OpenID_URINorm_TestCase(
+    function __construct(
                                $name, $uri, $expected)
     {
 
@@ -53,7 +53,7 @@ class Tests_Auth_OpenID_URINorm extends PHPUnit_Framework_TestSuite {
         return $cases;
     }
 
-    function Tests_Auth_OpenID_URINorm($name)
+    function __construct($name)
     {
         $this->setName($name);
         $cases = $this->_readTestCases();

--- a/Tests/Auth/OpenID/VerifyDisco.php
+++ b/Tests/Auth/OpenID/VerifyDisco.php
@@ -52,7 +52,7 @@ class _DiscoverAndVerify extends OpenIDTestMixin {
 }
 
 class _Tests_discoveryOverride {
-    function _Tests_discoveryOverride($endpoint)
+    function __construct($endpoint)
     {
         $this->endpoint = $endpoint;
     }

--- a/Tests/Auth/Yadis/Discover_Yadis.php
+++ b/Tests/Auth/Yadis/Discover_Yadis.php
@@ -26,7 +26,7 @@ function mkResponse($data)
     return $r;
 }
 class TestFetcher {
-    function TestFetcher($base_url)
+    function __construct($base_url)
     {
         $this->base_url = $base_url;
     }
@@ -73,7 +73,7 @@ class NoContentTypeFetcher {
 }
 
 class MockFetcher {
-    function MockFetcher() {
+    function __construct() {
         $this->count = 0;
     }
 
@@ -103,7 +103,7 @@ class TestSecondGet extends PHPUnit_Framework_TestCase {
 class _TestCase extends PHPUnit_Framework_TestCase {
     var $base_url = 'http://invalid.unittest/';
 
-    function _TestCase($input_name, $id_name, $result_name, $success)
+    function __construct($input_name, $id_name, $result_name, $success)
     {
       parent::__construct();
         $this->input_name = $input_name;
@@ -169,7 +169,7 @@ class Tests_Auth_Yadis_Discover_Yadis extends PHPUnit_Framework_TestSuite {
         return "Tests_Auth_Yadis_Discover_Yadis";
     }
 
-    function Tests_Auth_Yadis_Discover_Yadis()
+    function __construct()
     {
         global $testlist;
 

--- a/Tests/Auth/Yadis/ParseHTML.php
+++ b/Tests/Auth/Yadis/ParseHTML.php
@@ -17,7 +17,7 @@ require_once 'Tests/Auth/Yadis/TestUtil.php';
 require_once 'Auth/Yadis/ParseHTML.php';
 
 class Tests_Auth_Yadis_ParseTest extends PHPUnit_Framework_TestCase {
-    function Tests_Auth_Yadis_ParseTest($case)
+    function __construct($case)
     {
         list($result, $comment, $html) = $case;
 
@@ -72,7 +72,7 @@ class Tests_Auth_Yadis_ParseHTML extends PHPUnit_Framework_TestSuite {
         return $tests;
     }
 
-    function Tests_Auth_Yadis_ParseHTML()
+    function __construct()
     {
         $test_data = Tests_Auth_Yadis_readdata('test1-parsehtml.txt');
 

--- a/Tests/Auth/Yadis/XRI.php
+++ b/Tests/Auth/Yadis/XRI.php
@@ -131,7 +131,7 @@ class Tests_Auth_Yadis_XRI extends PHPUnit_Framework_TestSuite {
         return "Tests_Auth_Yadis_XRI";
     }
 
-    function Tests_Auth_Yadis_XRI()
+    function __construct()
     {
         $this->addTest(new Tests_Auth_Yadis_ProxyQueryTestCase());
         $this->addTest(new Tests_Auth_Yadis_XriEscapingTestCase());

--- a/Tests/Auth/Yadis/Yadis.php
+++ b/Tests/Auth/Yadis/Yadis.php
@@ -9,8 +9,7 @@ require_once 'Tests/Auth/Yadis/TestUtil.php';
 
 class Tests_Auth_Yadis_DiscoveryTest extends PHPUnit_Framework_TestCase {
 
-    function Tests_Auth_Yadis_DiscoveryTest($input_url, $redir_uri,
-                                                $xrds_uri, $num)
+    function __construct($input_url, $redir_uri, $xrds_uri, $num)
     {
         $this->input_url = $input_url;
         $this->redir_uri = $redir_uri;
@@ -68,7 +67,7 @@ class Tests_Auth_Yadis_Yadis extends PHPUnit_Framework_TestSuite {
         return $tests;
     }
 
-    function Tests_Auth_Yadis_Yadis()
+    function __construct()
     {
         $test_data = file_get_contents('http://www.openidenabled.com/resources/yadis-test/discover/manifest.txt');
 

--- a/contrib/signed_assertions/AP.php
+++ b/contrib/signed_assertions/AP.php
@@ -42,7 +42,7 @@ class Attribute_Provider
     * @param string $acsURI - URI of the signer.
     * @param string $assertionTemplate - SAML template used for assertion
     */
-   function Attribute_Provider($public_key_certificate,$private_key,$notBefore,$notOnOrAfter,$rsadsa,$acsURI,
+   function __construct($public_key_certificate,$private_key,$notBefore,$notOnOrAfter,$rsadsa,$acsURI,
                                $assertionTemplate)
    {
       $this->public_key_certificate=$public_key_certificate;


### PR DESCRIPTION
It still has few compatibility issues in tests according to the php7cc report:

```
File: C:\www\php-openid\Tests\Auth\OpenID\Consumer.php
> Line 1530: Possible object property creation during by-reference assignment
    $this->consumer->fetcher =& $this->fetcher;
> Line 1621: Possible object property creation during by-reference assignment
    $this->consumer->fetcher =& $this->fetcher;
> Line 2100: Possible object property creation during by-reference assignment
    $this->consumer->check_endpoint =& $this->endpoint;


File: C:\www\php-openid\Tests\Auth\OpenID\Server.php
> Line 2141: String containing number in hexadecimal notation
    '0x3999';
```

But I'm not sure if they are critical