### PR TITLE
Composer install steps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,12 @@
     ],
     "require": {
         "php": ">=4.3",
-        "ext-gmp": "*",
+        "ext-bcmath": "*",
         "ext-curl": "*",
         "ext-dom": "*"
+    },
+    "suggest": {
+        "ext-gmp": "*"
     },
     "autoload": {
         "classmap": ["Auth"]

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "php": ">=4.3",
         "ext-bcmath": "*",
         "ext-curl": "*",
-        "ext-dom": "*"
+        "ext-dom": "*",
+        "pear-pear.php.net/MDB2": "*"
     },
     "suggest": {
         "ext-gmp": "*"

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,12 @@
             "homepage": "http://www.openidenabled.com"
         }
     ],
+    "repositories": [
+        {
+            "type": "pear",
+            "url": "https://pear.php.net"
+        }
+    ],
     "require": {
         "php": ">=4.3",
         "ext-bcmath": "*",
@@ -20,8 +26,14 @@
     "suggest": {
         "ext-gmp": "*"
     },
+    "require-dev": {
+        "pear-pear.php.net/PHPUnit": "^1.0"
+    },
     "autoload": {
         "classmap": ["Auth"]
+    },
+    "autoload-dev": {
+        "classmap": ["Tests/Auth"]
     },
     "include-path": ["."]
 }


### PR DESCRIPTION
Simplify the install process by updating the Composer package definition.

1. Update platform dependencies to require `ext-bcmath` and suggest `ext-gmp`
1. Install `pear.php.net/PHPUnit` version 1.x as dev dependency
1. Install `pear.php.net/MDB2` as dependency