### PR TITLE
Remove check for result where it should be null

### DIFF
--- a/Auth/OpenID/Consumer.php
+++ b/Auth/OpenID/Consumer.php
@@ -1263,7 +1263,7 @@ class Auth_OpenID_GenericConsumer {
             foreach ($to_match_endpoints as $to_match_endpoint) {
                 $result = $this->_verifyDiscoverySingle($endpoint, $to_match_endpoint);
 
-                if ($result && !Auth_OpenID::isFailure($result)) {
+                if (!Auth_OpenID::isFailure($result)) {
                     // It matches, so discover verification has
                     // succeeded. Return this endpoint.
                     return $endpoint;


### PR DESCRIPTION
$result here should be null if the endpoint is valid or Auth_OpenID_FailureResponse if it is not. Checking whether $result is true and not null caused the valid endpoint to never be returned.