### PR TITLE
Fix Auth_OpenID_SuccessResponse

### DIFF
--- a/Auth/OpenID/Consumer.php
+++ b/Auth/OpenID/Consumer.php
@@ -2076,10 +2076,10 @@ class Auth_OpenID_ConsumerResponse {
     public $status = null;
 
     /** @var null|string */
-    private $identity_url = null;
+    public $identity_url = null;
 
     /** @var Auth_OpenID_ServiceEndpoint */
-    private $endpoint;
+    public $endpoint;
 
     /**
      * @param Auth_OpenID_ServiceEndpoint|null $endpoint
@@ -2138,10 +2138,6 @@ class Auth_OpenID_ConsumerResponse {
 class Auth_OpenID_SuccessResponse extends Auth_OpenID_ConsumerResponse {
     public $status = Auth_OpenID_SUCCESS;
 
-    /** @var Auth_OpenID_ServiceEndpoint */
-    public $endpoint;
-    /** @var string */
-    public $identity_url;
     /** @var array */
     public $signed_args = array();
     /** @var Auth_OpenID_Message */


### PR DESCRIPTION
In 263a6c7f299a71f5dd59a7feb2d62b93bb6a577c, @liayn made `Auth_OpenID_ConsumerResponse::identity_url` and `Auth_OpenID_ConsumerResponse::endpoint` private, then redeclared them as public in subclass `Auth_OpenID_SuccessResponse`, breaking functionality such as calling `Auth_OpenID_ConsumerResponse::getDisplayIdentifier()` on instances of `Auth_OpenID_SuccessResponse`. To fix that, I made the properties on `Auth_OpenID_ConsumerResponse` public as they were before and removed the redeclarations in `Auth_OpenID_SuccessResponse`.