### PR TITLE
Fixed a bug that SqlStore::getAssociation() return `issued` instead of `assoc`

### DIFF
--- a/Auth/OpenID/SQLStore.php
+++ b/Auth/OpenID/SQLStore.php
@@ -465,7 +465,7 @@ class Auth_OpenID_SQLStore extends Auth_OpenID_OpenIDStore {
                                 $associations);
 
                 // return the most recently issued one.
-                list($assoc) = $associations[0];
+                list(, $assoc) = $associations[0];
                 return $assoc;
             } else {
                 return null;


### PR DESCRIPTION
See: https://github.com/openid/php-openid/pull/136/files#diff-afabe645d659d7208546bbfdfec02d26R468