### PR TITLE
Remove "version" from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
     "name": "openid/php-openid",
-    "version": "3.0.0",
     "description": "OpenID library for PHP5",
     "keywords": ["openid", "authentication", "yadis", "auth"],
     "license": "Apache-2.0",


### PR DESCRIPTION
Never add "version" to composer.json if you have a repository and can add tags. Otherwise every commit will be described as "version 3.0.0" after the first commit, and this will confuse Composer, because it is not true. Only use "version" in a context where no other ways of designating a version are available.

Tagging the version in this repo is enough for Composer to function.