### PR TITLE
Made a variable public

### DIFF
--- a/Auth/OpenID/Message.php
+++ b/Auth/OpenID/Message.php
@@ -474,7 +474,7 @@ class Auth_OpenID_Message {
     /**
      * @var Auth_OpenID_NamespaceMap
      */
-    private $namespaces;
+    public $namespaces;
 
     /**
      * @var null|string


### PR DESCRIPTION
The `Auth_OpenID_Message::$namespaces` is referenced in several places.  Without additional refactoring, it needs to stay public.