### PR TITLE
Update Auth_OpenID_VERSION

### DIFF
--- a/Auth/OpenID.php
+++ b/Auth/OpenID.php
@@ -20,7 +20,7 @@
 /**
  * The library version string
  */
-define('Auth_OpenID_VERSION', '2.2.2');
+define('Auth_OpenID_VERSION', '3.0.3');
 
 /**
  * Require the fetcher code.


### PR DESCRIPTION
This fixes the User-Agent improperly reported as `php-openid/2.2.2` via the `Auth_OpenID_USER_AGENT` define. 

I wrote `3.0.3` as I imagine a new version is needed to release this.